### PR TITLE
Fix netstandard tests : Add target dll and nunit package references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ obj
 *.nupkg
 *ReSharper*
 /packages
+.idea/
+.vs/
+.vscode/

--- a/src/Mono.Reflection.Tests/Mono.Reflection.Tests.csproj
+++ b/src/Mono.Reflection.Tests/Mono.Reflection.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net35</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net35</TargetFrameworks>
     <Version>1.1.1</Version>
     <AssemblyVersion>1.1.0.0</AssemblyVersion>
     <Authors>Jb Evain</Authors>
@@ -10,23 +10,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Mono.Reflection\Mono.Reflection.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="target.dll">
-    <LogicalName>target.dll</LogicalName>
+      <LogicalName>target.dll</LogicalName>
     </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="target.il" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>
 </Project>

--- a/src/Mono.Reflection.Tests/Mono.Reflection.Tests.csproj
+++ b/src/Mono.Reflection.Tests/Mono.Reflection.Tests.csproj
@@ -16,4 +16,17 @@
   <ItemGroup>
     <ProjectReference Include="..\Mono.Reflection\Mono.Reflection.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="target.dll">
+    <LogicalName>target.dll</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="target.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
`Cause` :
`dotnet test` does not run any tests.

`Solved by` :
1. Adding nunit package reference : Followed https://github.com/nunit/docs/wiki/.NET-Core-and-.NET-Standard
After this, I saw failures while running dotnet test on Tests project in current branch :
```
Total tests: 14. Passed: 2. Failed: 12. Skipped: 0.
Test Run Failed.
Test execution time: 1.0736 Seconds
```

2. Embedded target.dll resource.
```
E:\work\git_repos\mono.reflection\src\Mono.Reflection.Tests>dotnet test
Build started, please wait...
Build completed.

Test run for mono.reflection\src\Mono.Reflection.Tests\bin\Debug\netcoreapp2.0\Mono.Reflection.Tests.dll(.NETCoreApp,Version=v2.0)
Microsoft (R) Test Execution Command Line Tool Version 15.3.0-preview-20170628-02
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
NUnit Adapter 3.9.0.0: Test execution started
Running all tests in mono.reflection\src\Mono.Reflection.Tests\bin\Debug\netcoreapp2.0\Mono.Reflection.Tests.dll
NUnit3TestExecutor converted 14 of 14 NUnit test cases
NUnit Adapter 3.9.0.0: Test execution complete

Total tests: 14. Passed: 14. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 0.9465 Seconds
```

